### PR TITLE
Fix the lost ratio problem.

### DIFF
--- a/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
+++ b/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
@@ -195,8 +195,8 @@ public abstract class BaseSliderView {
         if(getError() != 0){
             rq.error(getError());
         }
-        rq.fit();
-
+        rq.fit().centerCrop();
+        
         rq.into(targetImageView,new Callback() {
             @Override
             public void onSuccess() {


### PR DESCRIPTION
If the bitmap's ratio is not fit ImageView's ratio.
rq.fit() will cause the bitmap to be stretched to fit the imageView,it looks so ugly.

so .fit().centerCrop() can sovle the problem.

see below.
![screenshot_2014-06-10-16-40-36](https://cloud.githubusercontent.com/assets/2627625/3227468/5aa37590-f07b-11e3-8026-1f8d73374d08.png)
![screenshot_2014-06-10-16-41-23](https://cloud.githubusercontent.com/assets/2627625/3227469/5aa78784-f07b-11e3-8606-5ed4d861b978.png)
