### PR TITLE
Update bindEventAndShow

### DIFF
--- a/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
+++ b/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
@@ -189,6 +189,9 @@ public abstract class BaseSliderView {
             }
         });
 
+        if (targetImageView == null)
+            return;
+
         mLoadListener.onStart(me);
 
         Picasso p = Picasso.with(mContext);


### PR DESCRIPTION
Passing null as targetImageView to bindEventAndShow(final View v, ImageView targetImageView) will no longer crash the app. This allows the binding of the onClick event to the view, without loading the image (if one loads the image by himself).
