### PR TITLE
Update BaseSliderView.java

### DIFF
--- a/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
+++ b/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
@@ -243,6 +243,9 @@ public abstract class BaseSliderView {
                 if(mLoadListener != null){
                     mLoadListener.onEnd(false,me);
                 }
+                if(v.findViewById(R.id.loading_bar) != null){
+                    v.findViewById(R.id.loading_bar).setVisibility(View.INVISIBLE);
+                }
             }
         });
    }


### PR DESCRIPTION
The proposed idea is when the proressBar does not disappear when there is a download error by picasso.
