### PR TITLE
fixes #60

### DIFF
--- a/library/src/main/java/com/daimajia/slider/library/SliderLayout.java
+++ b/library/src/main/java/com/daimajia/slider/library/SliderLayout.java
@@ -625,6 +625,7 @@ public class SliderLayout extends RelativeLayout{
         if(getRealAdapter()!=null){
             getRealAdapter().removeSliderAt(position);
             mViewPager.setCurrentItem(mViewPager.getCurrentItem(),false);
+            mViewPager.setAdapter(getWrapperAdapter());
         }
     }
 
@@ -638,6 +639,7 @@ public class SliderLayout extends RelativeLayout{
             //a small bug, but fixed by this trick.
             //bug: when remove adapter's all the sliders.some caching slider still alive.
             mViewPager.setCurrentItem(mViewPager.getCurrentItem() +  count,false);
+            mViewPager.setAdapter(getWrapperAdapter());
         }
     }
 


### PR DESCRIPTION
When removing all slides from that view, then the slide remains and is overlapping the new ones.
When setting the Adapter again it forces the regeneration of the ViewPager Views.