### PR TITLE
refactoring BaseSliderView

### DIFF
--- a/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
+++ b/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
@@ -192,7 +192,9 @@ public abstract class BaseSliderView {
         if (targetImageView == null)
             return;
 
-        mLoadListener.onStart(me);
+        if (mLoadListener != null) {
+            mLoadListener.onStart(me);
+        }
 
         Picasso p = Picasso.with(mContext);
         RequestCreator rq = null;


### PR DESCRIPTION
- If call BaseSliderView.getView() before set ImageLoadListener, It occur NullPointerException. So I add null checking logic.