### PR TITLE
Adding and accessing Bundles on BaseSliderView.java

### DIFF
--- a/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
+++ b/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
@@ -58,7 +58,6 @@ public abstract class BaseSliderView {
 
     protected BaseSliderView(Context context) {
         mContext = context;
-        this.mBundle = new Bundle();
     }
 
     /**
@@ -135,6 +134,16 @@ public abstract class BaseSliderView {
                     "you only have permission to call it once");
         }
         mRes = res;
+        return this;
+    }
+
+    /**
+     * lets users add a bundle of additional information
+     * @param bundle
+     * @return
+     */
+    public BaseSliderView bundle(Bundle bundle){
+        mBundle = bundle;
         return this;
     }
 


### PR DESCRIPTION
Users couldn't actually add a Bundle via BaseSliderView. BaseSliderView.bundle() lets you add a Bundle to each slider, which can be accessed by BaseSliderView.getBundle().