### PR TITLE
Fix demo to prevent memory leak on device orientation change

### DIFF
--- a/demo/src/main/java/com/daimajia/slider/demo/MainActivity.java
+++ b/demo/src/main/java/com/daimajia/slider/demo/MainActivity.java
@@ -81,6 +81,13 @@ public class MainActivity extends ActionBarActivity implements BaseSliderView.On
     }
 
     @Override
+    protected void onStop() {
+        // To prevent a memory leak on rotation, make sure to call stopAutoCycle() on the slider before activity or fragment is destroyed
+        mDemoSlider.stopAutoCycle();
+        super.onStop();
+    }
+
+    @Override
     public void onSliderClick(BaseSliderView slider) {
         Toast.makeText(this,slider.getBundle().get("extra") + "",Toast.LENGTH_SHORT).show();
     }


### PR DESCRIPTION
This is as recommended in https://github.com/daimajia/AndroidImageSlider/issues/41
I verified that the leak is fixed with this change.
I also updated the wiki: https://github.com/daimajia/AndroidImageSlider/wiki/Start-Using