### PR TITLE
Allow specifying a Picasso instance to use when loading images

### DIFF
--- a/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
+++ b/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
@@ -47,6 +47,8 @@ public abstract class BaseSliderView {
 
     private String mDescription;
 
+    private Picasso mPicasso;
+
     /**
      * Scale type of the image.
      */
@@ -205,7 +207,7 @@ public abstract class BaseSliderView {
             mLoadListener.onStart(me);
         }
 
-        Picasso p = Picasso.with(mContext);
+        Picasso p = (mPicasso != null) ? mPicasso : Picasso.with(mContext);
         RequestCreator rq = null;
         if(mUrl!=null){
             rq = p.load(mUrl);
@@ -304,4 +306,23 @@ public abstract class BaseSliderView {
         public void onEnd(boolean result,BaseSliderView target);
     }
 
+    /**
+     * Get the last instance set via setPicasso(), or null if no user provided instance was set
+     *
+     * @return The current user-provided Picasso instance, or null if none
+     */
+    public Picasso getPicasso() {
+        return mPicasso;
+    }
+
+    /**
+     * Provide a Picasso instance to use when loading pictures, this is useful if you have a
+     * particular HTTP cache you would like to share.
+     *
+     * @param picasso The Picasso instance to use, may be null to let the system use the default
+     *                instance
+     */
+    public void setPicasso(Picasso picasso) {
+        mPicasso = picasso;
+    }
 }


### PR DESCRIPTION
In my application I'm already using Picasso and OkHttp to perform various image loading and HTTP requests. OkHttp and Picasso are able to share a common HTTP cache if the Picasso instance is configured correctly.

This change allows the user to supply a Picasso instance for AndroidImageSlider library to use. With this change I can turn on Picasso's debug indicators and I can see that the slider widget is using the same cache that the rest of my application is using.