### PR TITLE
Adding image rounding with Picasso Transformation

### DIFF
--- a/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
+++ b/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
@@ -9,6 +9,7 @@ import com.daimajia.slider.library.R;
 import com.squareup.picasso.Callback;
 import com.squareup.picasso.Picasso;
 import com.squareup.picasso.RequestCreator;
+import com.squareup.picasso.Transformation;
 
 import java.io.File;
 
@@ -48,6 +49,8 @@ public abstract class BaseSliderView {
     private String mDescription;
 
     private Picasso mPicasso;
+
+    private Transformation mTransformation;
 
     /**
      * Scale type of the image.
@@ -219,6 +222,10 @@ public abstract class BaseSliderView {
             return;
         }
 
+        if (mTransformation != null) {
+            rq.transform(mTransformation);
+        }
+
         if(rq == null){
             return;
         }
@@ -324,5 +331,10 @@ public abstract class BaseSliderView {
      */
     public void setPicasso(Picasso picasso) {
         mPicasso = picasso;
+    }
+
+    public BaseSliderView setTransformation(Transformation transformation) {
+        mTransformation = transformation;
+        return this;
     }
 }

--- a/library/src/main/java/com/daimajia/slider/library/Transformations/RoundedTransformation.java
+++ b/library/src/main/java/com/daimajia/slider/library/Transformations/RoundedTransformation.java
@@ -1,0 +1,42 @@
+package com.daimajia.slider.library.Transformations;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapShader;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.Shader;
+
+public class RoundedTransformation implements com.squareup.picasso.Transformation {
+    private final int radius;
+    private final int margin;
+
+    public RoundedTransformation(int margin, int radius) {
+        this.margin = margin;
+        this.radius = radius;
+    }
+
+    @Override
+    public Bitmap transform(Bitmap source) {
+        final Paint paint = new Paint();
+
+        paint.setAntiAlias(true);
+        paint.setShader(new BitmapShader(source, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP));
+
+        Bitmap output = Bitmap.createBitmap(source.getWidth(), source.getHeight(), Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(output);
+        canvas.drawRoundRect(new RectF(margin, margin, source.getWidth() - margin, source.getHeight() - margin), radius, radius, paint);
+
+        if (source != output) {
+            source.recycle();
+        }
+
+        return output;
+    }
+
+    @Override
+    public String key() {
+        return "rounded";
+    }
+}
+


### PR DESCRIPTION
Many different image transformations can be added by creating new Transformations. I just added Rounding transformation. 

Ex. this code adds margin and radius to the image.

```
textSliderView
        .setTransformation(new RoundedTransformation(10, 25))
        .description(name)
        .image(file_maps.get(name))
        .setScaleType(BaseSliderView.ScaleType.Fit)
        .setOnSliderClickListener(this);
```
