### PR TITLE
Add a new scale type OnlyScaleDown

### DIFF
--- a/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
+++ b/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
@@ -55,7 +55,7 @@ public abstract class BaseSliderView {
     private ScaleType mScaleType = ScaleType.Fit;
 
     public enum ScaleType{
-        CenterCrop, CenterInside, Fit, FitCenterCrop
+        CenterCrop, CenterInside, Fit, FitCenterCrop, OnlyScaleDown
     }
 
     protected BaseSliderView(Context context) {
@@ -240,6 +240,9 @@ public abstract class BaseSliderView {
                 break;
             case CenterInside:
                 rq.fit().centerInside();
+                break;
+            case OnlyScaleDown:
+                rq.onlyScaleDown();
                 break;
         }
 

--- a/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
+++ b/library/src/main/java/com/daimajia/slider/library/SliderTypes/BaseSliderView.java
@@ -54,6 +54,14 @@ public abstract class BaseSliderView {
      */
     private ScaleType mScaleType = ScaleType.Fit;
 
+    private int resizeWidth = -1;
+    private int resizeHeight = -1;
+
+    public void setResizeDimensions(int resizeWidth, int resizeHeight) {
+        this.resizeHeight = resizeHeight;
+        this.resizeWidth = resizeWidth;
+    }
+
     public enum ScaleType{
         CenterCrop, CenterInside, Fit, FitCenterCrop, OnlyScaleDown
     }
@@ -242,7 +250,11 @@ public abstract class BaseSliderView {
                 rq.fit().centerInside();
                 break;
             case OnlyScaleDown:
-                rq.onlyScaleDown();
+                if (resizeWidth == -1 && resizeHeight == -1) {
+                    throw new IllegalArgumentException("At least one dimension has to be a positive number");
+                }
+                rq.resize(resizeWidth, resizeHeight)
+                    .onlyScaleDown();
                 break;
         }
 


### PR DESCRIPTION
Because of a memory leak I found using Picasso a big imageviews I'd like to add this new ScaleType to AndroidImageSlider to set the image to the dimensions I want and to say to Picasso I only want to scale down the image. 

The commits are working in my project as I've added the library from my fork to the project
