### PR TITLE
Modify: bug fix: update recoverCycle time

### DIFF
--- a/library/src/main/java/com/daimajia/slider/library/SliderLayout.java
+++ b/library/src/main/java/com/daimajia/slider/library/SliderLayout.java
@@ -342,7 +342,7 @@ public class SliderLayout extends RelativeLayout{
                     startAutoCycle();
                 }
             };
-            mResumingTimer.schedule(mResumingTask, 6000);
+            mResumingTimer.schedule(mResumingTask, mSliderDuration);
         }
     }
 


### PR DESCRIPTION
当touch结束后，恢复自动滚动的时间是错误的，原因是代码里写死为6000ms。
